### PR TITLE
Changes to accomodate preferred region during keystone authN

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -144,7 +144,7 @@
 		</dependency>
 		<dependency>
 			<groupId>org.mockito</groupId>
-			<artifactId>mockito-core</artifactId>
+			<artifactId>mockito-all</artifactId>
 			<version>${mockito.version}</version>
 			<scope>test</scope>
 		</dependency>

--- a/src/main/java/org/swiftexplorer/gui/MainPanel.java
+++ b/src/main/java/org/swiftexplorer/gui/MainPanel.java
@@ -166,6 +166,8 @@ import javax.swing.tree.TreeModel;
 import javax.swing.tree.TreePath;
 import javax.swing.tree.TreeSelectionModel;
 
+import org.apache.commons.lang.StringUtils;
+import org.javaswift.joss.client.factory.AccountConfig;
 import org.javaswift.joss.client.factory.AuthenticationMethod;
 import org.javaswift.joss.exception.CommandException;
 import org.javaswift.joss.exception.CommandExceptionError;
@@ -1020,10 +1022,10 @@ public class MainPanel extends JPanel implements SwiftOperations.SwiftCallback {
     
     
     public void onLogin() {
-        final JDialog loginDialog = new JDialog(owner, getLocalizedString("Login"));
+        final JDialog loginDialog = new JDialog(owner, getLocalizedString("Generic_Login"));
         final LoginPanel loginPanel = new LoginPanel(new LoginCallback() {
             @Override
-            public void doLogin(String authUrl, String tenant, String username, char[] pass) {
+            public void doLogin(String authUrl, String tenant, String username, char[] pass, String preferredRegion) {
             	SwiftCallback cb = GuiTreadingUtils.guiThreadSafe(SwiftCallback.class, new CloudieCallbackWrapper(callback) {
                     @Override
                     public void onLoginSuccess() {
@@ -1036,10 +1038,15 @@ public class MainPanel extends JPanel implements SwiftOperations.SwiftCallback {
                         JOptionPane.showMessageDialog(loginDialog,  getLocalizedString("Login_Failed") + "\n" + ex.toString(), getLocalizedString("Error"), JOptionPane.ERROR_MESSAGE);
                     }
                 });
-            	if (allowCustomeSwiftSettings)
-            		ops.login(AccountConfigFactory.getKeystoneAccountConfig(), config.getSwiftSettings(), authUrl, tenant, username, new String(pass), cb);
-            	else
-            		ops.login(AccountConfigFactory.getKeystoneAccountConfig(), authUrl, tenant, username, new String(pass), cb);
+				AccountConfig accountConfig = AccountConfigFactory.getKeystoneAccountConfig();
+				if (!StringUtils.isEmpty(preferredRegion)) {
+					accountConfig.setPreferredRegion(preferredRegion);
+				}
+				if (allowCustomeSwiftSettings)
+					ops.login(accountConfig, config.getSwiftSettings(), authUrl, tenant, username, new String(pass),
+							cb);
+				else
+					ops.login(accountConfig, authUrl, tenant, username, new String(pass), cb);
             }
         }, credentialsStore, stringsBundle);
         try {

--- a/src/main/java/org/swiftexplorer/gui/login/CredentialsStore.java
+++ b/src/main/java/org/swiftexplorer/gui/login/CredentialsStore.java
@@ -33,6 +33,7 @@ public class CredentialsStore {
         public String tenant;
         public String username;
         public char[] password;
+        public String preferredRegion;
 
         @Override
         public boolean equals(Object obj) {
@@ -82,6 +83,7 @@ public class CredentialsStore {
         cr.tenant = node.get("tenant", "");
         cr.username = node.get("username", "");
         cr.password = garble(node.get("password", ""));
+        cr.preferredRegion = node.get("preferredRegion", "");
         return cr;
     }
 
@@ -118,6 +120,7 @@ public class CredentialsStore {
         node.put("tenant", cr.tenant);
         node.put("username", cr.username);
         node.put("password", String.valueOf(garble(cr.password)));
+        node.put("preferredRegion", cr.preferredRegion);
     }
 
     //

--- a/src/main/java/org/swiftexplorer/gui/login/LoginPanel.java
+++ b/src/main/java/org/swiftexplorer/gui/login/LoginPanel.java
@@ -124,7 +124,7 @@ public class LoginPanel extends JPanel {
         box.add(new LabelComponentPanel("Tenant", tenant));
         box.add(new LabelComponentPanel("Username", username));
         box.add(new LabelComponentPanel("Password", password));
-        box.add(new LabelComponentPanel("Preferred Region", preferredRegion));
+        box.add(new LabelComponentPanel("Preferred Region (optional)", preferredRegion));
         //
         outer.add(box);
         outer.add(warn);
@@ -167,6 +167,7 @@ public class LoginPanel extends JPanel {
                         tenant.setText(cr.tenant);
                         username.setText(cr.username);
                         password.setText(String.valueOf(cr.password));
+                        preferredRegion.setText(cr.preferredRegion);
                         enableDisable();
                     }
                 }
@@ -180,6 +181,7 @@ public class LoginPanel extends JPanel {
         tenant.setText("");
         username.setText("");
         password.setText("");
+        preferredRegion.setText("");
         enableDisable();
     }
 
@@ -196,6 +198,7 @@ public class LoginPanel extends JPanel {
                 credentials.username = "";
                 credentials.password = new char[0];
                 credentials.authUrl = "";
+                credentials.preferredRegion = "";
                 model.insertElementAt(credentials, 0);
                 savedCredentials.setSelectedIndex(0);
             }
@@ -226,6 +229,7 @@ public class LoginPanel extends JPanel {
         tenant.getDocument().addDocumentListener(lst);
         username.getDocument().addDocumentListener(lst);
         password.getDocument().addDocumentListener(lst);
+        preferredRegion.getDocument().addDocumentListener(lst);
     }
 
     private void enableDisable() {
@@ -256,6 +260,7 @@ public class LoginPanel extends JPanel {
         cr.tenant = tenant.getText().trim();
         cr.username = username.getText().trim();
         cr.password = password.getPassword();
+        cr.preferredRegion = preferredRegion.getText().trim();
         credentialsStore.save(cr);
         refreshCredentials();
         savedCredentials.setSelectedItem(cr);

--- a/src/main/java/org/swiftexplorer/gui/login/LoginPanel.java
+++ b/src/main/java/org/swiftexplorer/gui/login/LoginPanel.java
@@ -63,7 +63,7 @@ public class LoginPanel extends JPanel {
 	private static final long serialVersionUID = 1L;
 
 	public interface LoginCallback {
-        void doLogin(String authUrl, String tenant, String username, char[] pass);
+        void doLogin(String authUrl, String tenant, String username, char[] pass, String preferredRegion);
     }
 
     private Action okAction = null ;
@@ -82,6 +82,7 @@ public class LoginPanel extends JPanel {
     private JTextField tenant = new JTextField();
     private JTextField username = new JTextField();
     private JPasswordField password = new JPasswordField();
+    private JTextField preferredRegion = new JTextField();
     private JLabel warningLabel = null ;
 
     private LoginCallback callback;
@@ -123,6 +124,7 @@ public class LoginPanel extends JPanel {
         box.add(new LabelComponentPanel("Tenant", tenant));
         box.add(new LabelComponentPanel("Username", username));
         box.add(new LabelComponentPanel("Password", password));
+        box.add(new LabelComponentPanel("Preferred Region", preferredRegion));
         //
         outer.add(box);
         outer.add(warn);
@@ -241,7 +243,7 @@ public class LoginPanel extends JPanel {
     }
 
     public void onOk() {
-        callback.doLogin(authUrl.getText().trim(), tenant.getText().trim(), username.getText().trim(), password.getPassword());
+        callback.doLogin(authUrl.getText().trim(), tenant.getText().trim(), username.getText().trim(), password.getPassword(), preferredRegion.getText().trim());
     }
 
     public void onCancel() {

--- a/src/main/java/org/swiftexplorer/swift/operations/SwiftOperationsImpl.java
+++ b/src/main/java/org/swiftexplorer/swift/operations/SwiftOperationsImpl.java
@@ -61,6 +61,7 @@ import java.util.Set;
 import java.util.TreeSet;
 import java.util.concurrent.atomic.AtomicInteger;
 
+import org.apache.commons.lang.StringUtils;
 import org.javaswift.joss.client.factory.AccountConfig;
 import org.javaswift.joss.client.factory.AccountFactory;
 import org.javaswift.joss.exception.CommandException;
@@ -190,13 +191,18 @@ public class SwiftOperationsImpl implements SwiftOperations {
     @Override
     public synchronized void login(AccountConfig accConf, HasSwiftSettings swiftSettings, String url, String tenant, String user, String pass, SwiftCallback callback) {
 
-		String preferredRegion = null ;
+		String preferredRegion = null;
+
 		if (swiftSettings != null) {
 			
 	    	this.segmentationSize = swiftSettings.getSegmentationSize() ;
 	    	useCustomSegmentation = true ;
 	    	preferredRegion = swiftSettings.getPreferredRegion() ;
 	    	preferredRegion = ((preferredRegion == null || preferredRegion.trim().isEmpty()) ? (null) : (preferredRegion.trim())) ;
+			if (accConf != null && !StringUtils.isEmpty(accConf.getPreferredRegion())) {
+				// Override this property from dialog screen
+				preferredRegion = accConf.getPreferredRegion();
+			}
 		}
 		
     	account = new AccountFactory(accConf).setPreferredRegion(preferredRegion).setUsername(user).setPassword(pass).setTenantName(tenant).setAuthUrl(url).createAccount();

--- a/src/test/java/org/swiftexplorer/gui/login/CredentialsStoreTest.java
+++ b/src/test/java/org/swiftexplorer/gui/login/CredentialsStoreTest.java
@@ -35,6 +35,7 @@ public class CredentialsStoreTest {
         cr.tenant = "test-tenant";
         cr.username = "test-user";
         cr.password = "boterhammetpindakaas".toCharArray();
+        cr.preferredRegion = "myregion1";
     }
 
     @Test

--- a/src/test/java/org/swiftexplorer/gui/login/LoginPanelTest.java
+++ b/src/test/java/org/swiftexplorer/gui/login/LoginPanelTest.java
@@ -47,7 +47,7 @@ public class LoginPanelTest {
         LoginPanel loginPanel = new LoginPanel(callback, credentialsStore, null);
         loginPanel.onOk();
         //
-        Mockito.verify(callback).doLogin(Mockito.anyString(), Mockito.anyString(), Mockito.anyString(), Mockito.any(char[].class));
+        Mockito.verify(callback).doLogin(Mockito.anyString(), Mockito.anyString(), Mockito.anyString(), Mockito.any(char[].class), Mockito.anyString());
     }
 
 }


### PR DESCRIPTION
Currently, preferredRegion for keystone authN can be specified via swiftsettings.xml. But it is vague and not documented clearly.

Made changes to specify preferred region through the keystone Login dialog. Also, an ability to save/restore this value in user preferences

Fixed test failures by correcting the MockIto library